### PR TITLE
Refine backend and remove frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# DCF_UI
+# DCF UI
+
+This repository provides a simple three-stage DCF engine usable from Python via a CLI or API.
+
+## Backend
+
+The backend is built with FastAPI. The main endpoint `/dcf` receives a `MultiStageDCFConfig` describing the forecast stages and returns the present value of the cash flows.
+
+### Run the API
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.api:app --reload
+```
+
+### CLI usage
+
+You can compute the enterprise value without running the web server:
+
+```bash
+python -m backend.cli sample_config.json
+```
+

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from ..dcf_engine.config import StageConfig, MultiStageDCFConfig
+from ..dcf_engine.model import enterprise_value
+
+app = FastAPI(title="DCF API")
+
+
+class StageConfigModel(BaseModel):
+    years: int
+    driver_source: str
+    revenue_growth: list[float] | None = None
+    margin: list[float] | None = None
+    reinvestment_rate: list[float] | None = None
+    roic_start: float | None = None
+    roic_end: float | None = None
+    perp_growth: float | None = None
+
+
+class DCFConfigModel(BaseModel):
+    stages: list[StageConfigModel]
+    wacc: float
+    tax_rate: float
+    initial_revenue: float
+    initial_invested_capital: float
+
+
+@app.post("/dcf")
+def run_dcf(config: DCFConfigModel) -> float:
+    stages = [StageConfig(**stage.dict()) for stage in config.stages]
+    ms_config = MultiStageDCFConfig(
+        stages=stages,
+        wacc=config.wacc,
+        tax_rate=config.tax_rate,
+        initial_revenue=config.initial_revenue,
+        initial_invested_capital=config.initial_invested_capital,
+    )
+    value = enterprise_value(ms_config)
+    return value
+

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,0 +1,33 @@
+import json
+import argparse
+
+from .dcf_engine.config import StageConfig, MultiStageDCFConfig
+from .dcf_engine.model import enterprise_value
+
+
+def load_config(path: str) -> MultiStageDCFConfig:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    stages = [StageConfig(**s) for s in data["stages"]]
+    return MultiStageDCFConfig(
+        stages=stages,
+        wacc=data["wacc"],
+        tax_rate=data["tax_rate"],
+        initial_revenue=data["initial_revenue"],
+        initial_invested_capital=data["initial_invested_capital"],
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run DCF model from JSON config")
+    parser.add_argument("config", help="Path to config JSON")
+    args = parser.parse_args()
+    cfg = load_config(args.config)
+    value = enterprise_value(cfg)
+    print(f"Enterprise value: {value:.2f}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backend/dcf_engine/config.py
+++ b/backend/dcf_engine/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Literal, List, Optional
+
+@dataclass
+class StageConfig:
+    years: int
+    driver_source: Literal["consensus", "user", "fade", "perpetual"]
+    revenue_growth: Optional[List[float]] = None
+    margin: Optional[List[float]] = None
+    reinvestment_rate: Optional[List[float]] = None
+    roic_start: Optional[float] = None
+    roic_end: Optional[float] = None
+    perp_growth: Optional[float] = None
+
+@dataclass
+class MultiStageDCFConfig:
+    stages: List[StageConfig]
+    wacc: float
+    tax_rate: float
+    initial_revenue: float
+    initial_invested_capital: float
+

--- a/backend/dcf_engine/model.py
+++ b/backend/dcf_engine/model.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import List
+
+from .config import StageConfig, MultiStageDCFConfig
+
+
+def enterprise_value(config: MultiStageDCFConfig) -> float:
+    """Calculate enterprise value using a three-stage DCF."""
+    revenue = config.initial_revenue
+    invested = config.initial_invested_capital
+    value = 0.0
+    period = 0
+    roic = config.stages[0].roic_start or config.wacc
+
+    for stage in config.stages:
+        for idx in range(stage.years):
+            period += 1
+            growth = 0.0
+            margin = 0.0
+            reinv_rate = None
+            if stage.revenue_growth and idx < len(stage.revenue_growth):
+                growth = stage.revenue_growth[idx]
+            if stage.margin and idx < len(stage.margin):
+                margin = stage.margin[idx]
+            if stage.reinvestment_rate and idx < len(stage.reinvestment_rate):
+                reinv_rate = stage.reinvestment_rate[idx]
+
+            if stage.driver_source == "fade":
+                if stage.roic_start is None or stage.roic_end is None:
+                    raise ValueError("Fade stage requires roic_start and roic_end")
+                roic = stage.roic_start - (
+                    (stage.roic_start - stage.roic_end) * ((idx + 1) / stage.years)
+                )
+            elif stage.roic_start is not None:
+                roic = stage.roic_start
+
+            if reinv_rate is None:
+                reinv_rate = growth / roic if roic else 0.0
+
+            revenue_next = revenue * (1 + growth)
+            ebit = revenue_next * margin
+            nopat = ebit * (1 - config.tax_rate)
+            invested_next = invested + (revenue_next - revenue) * reinv_rate
+            fcf = nopat - (invested_next - invested)
+            discount = (1 + config.wacc) ** period
+            value += fcf / discount
+            revenue = revenue_next
+            invested = invested_next
+
+        if stage.driver_source == "perpetual":
+            g = stage.perp_growth or 0.0
+            terminal_nopat = revenue * margin * (1 - config.tax_rate)
+            terminal_reinv = g / roic if roic else 0.0
+            terminal_fcf = terminal_nopat * (1 - terminal_reinv)
+            terminal_value = terminal_fcf * (1 + g) / (config.wacc - g)
+            value += terminal_value / ((1 + config.wacc) ** period)
+            break
+
+    return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,0 +1,28 @@
+{
+  "stages": [
+    {
+      "years": 5,
+      "driver_source": "consensus",
+      "revenue_growth": [0.05, 0.05, 0.05, 0.05, 0.05],
+      "margin": [0.2, 0.21, 0.22, 0.23, 0.24],
+      "roic_start": 0.15
+    },
+    {
+      "years": 10,
+      "driver_source": "fade",
+      "roic_start": 0.15,
+      "roic_end": 0.10
+    },
+    {
+      "years": 1,
+      "driver_source": "perpetual",
+      "perp_growth": 0.03,
+      "roic_start": 0.10
+    }
+  ],
+  "wacc": 0.10,
+  "tax_rate": 0.25,
+  "initial_revenue": 100.0,
+  "initial_invested_capital": 100.0
+}
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.abspath('.'))
+
+from backend.dcf_engine.config import StageConfig, MultiStageDCFConfig
+from backend.dcf_engine.model import enterprise_value
+
+
+def test_enterprise_value_sample():
+    with open('sample_config.json', 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    stages = [StageConfig(**s) for s in data['stages']]
+    cfg = MultiStageDCFConfig(
+        stages=stages,
+        wacc=data['wacc'],
+        tax_rate=data['tax_rate'],
+        initial_revenue=data['initial_revenue'],
+        initial_invested_capital=data['initial_invested_capital'],
+    )
+    value = enterprise_value(cfg)
+    assert round(value, 2) == 64.69
+


### PR DESCRIPTION
## Summary
- drop unused React frontend and focus on API/CLI
- document running the FastAPI server and CLI usage
- add basic .gitignore

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874be858b60832784ef389ce4556a8a