### PR TITLE
Refine stage configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# DCF_UI
+# DCF UI
+
+This repository provides a simple three-stage DCF engine usable from Python via a CLI or API.
+
+## Backend
+
+The backend is built with FastAPI. The main endpoint `/dcf` receives a list of stage definitions and returns the present value of the cash flows.
+Each stage provides its own WACC and optional tax rate. Stage&nbsp;1 also carries the starting revenue and invested capital so no global block of parameters is required. Stage&nbsp;1 can take full consensus figures (revenue, EBIT/EBITDA and capex) or accept growth and margin paths. Stage&nbsp;2 only needs a WACC and length—the model fades ROIC to that cost of capital. The perpetual stage supplies its WACC and long‑run growth.
+
+### Run the API
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.api:app --reload
+```
+
+### CLI usage
+
+You can compute the enterprise value without running the web server:
+
+```bash
+python -m backend.cli sample_config.json
+```
+

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,37 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from ..dcf_engine.config import StageConfig, MultiStageDCFConfig
+from ..dcf_engine.model import enterprise_value
+
+app = FastAPI(title="DCF API")
+
+
+class StageConfigModel(BaseModel):
+    driver_source: str
+    wacc: float | list[float]
+    years: int | None = None
+    tax_rate: float | None = None
+    initial_revenue: float | None = None
+    initial_invested_capital: float | None = None
+    revenue: list[float] | None = None
+    operating_profit: list[float] | None = None
+    ebit: list[float] | None = None
+    ebitda: list[float] | None = None
+    capex: list[float] | None = None
+    revenue_growth: list[float] | None = None
+    margin: list[float] | None = None
+    perp_growth: float | None = None
+
+
+class DCFConfigModel(BaseModel):
+    stages: list[StageConfigModel]
+
+
+@app.post("/dcf")
+def run_dcf(config: DCFConfigModel) -> float:
+    stages = [StageConfig(**stage.dict()) for stage in config.stages]
+    ms_config = MultiStageDCFConfig(stages=stages)
+    value = enterprise_value(ms_config)
+    return value
+

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,0 +1,27 @@
+import json
+import argparse
+
+from .dcf_engine.config import StageConfig, MultiStageDCFConfig
+from .dcf_engine.model import enterprise_value
+
+
+def load_config(path: str) -> MultiStageDCFConfig:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    stages = [StageConfig(**s) for s in data["stages"]]
+    return MultiStageDCFConfig(stages=stages)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run DCF model from JSON config")
+    parser.add_argument("config", help="Path to config JSON")
+    args = parser.parse_args()
+    cfg = load_config(args.config)
+    value = enterprise_value(cfg)
+    print(f"Enterprise value: {value:.2f}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backend/dcf_engine/config.py
+++ b/backend/dcf_engine/config.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Literal, List, Optional, Union
+
+@dataclass
+class StageConfig:
+    driver_source: Literal["consensus", "user", "fade", "perpetual"]
+    wacc: Union[float, List[float]]
+    years: Optional[int] = None
+    # optional per-stage tax and starting values
+    tax_rate: Optional[float] = None
+    initial_revenue: Optional[float] = None
+    initial_invested_capital: Optional[float] = None
+    # Stage 1 explicit consensus inputs
+    revenue: Optional[List[float]] = None
+    operating_profit: Optional[List[float]] = None
+    ebit: Optional[List[float]] = None
+    ebitda: Optional[List[float]] = None
+    capex: Optional[List[float]] = None
+    # Stage 1 user-growth inputs
+    revenue_growth: Optional[List[float]] = None
+    margin: Optional[List[float]] = None
+    # perpetual stage
+    perp_growth: Optional[float] = None
+
+@dataclass
+class MultiStageDCFConfig:
+    stages: List[StageConfig]
+

--- a/backend/dcf_engine/model.py
+++ b/backend/dcf_engine/model.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .config import StageConfig, MultiStageDCFConfig
+
+
+def _wacc_series(wacc: float | List[float], years: int) -> Iterable[float]:
+    if isinstance(wacc, list):
+        return [wacc[min(i, len(wacc) - 1)] for i in range(years)]
+    return [wacc] * years
+
+
+def enterprise_value(config: MultiStageDCFConfig) -> float:
+    """Calculate enterprise value using a three-stage DCF."""
+    # use initial settings from the first stage
+    first = config.stages[0]
+    revenue = first.initial_revenue or 0.0
+    invested = first.initial_invested_capital or 0.0
+    tax_rate = first.tax_rate or 0.0
+    value = 0.0
+    period = 0
+    margin = 0.0
+    roic = 0.0
+    growth_last = 0.0
+
+    for idx_stage, stage in enumerate(config.stages):
+        if stage.driver_source == "perpetual":
+            wacc_val = stage.wacc if not isinstance(stage.wacc, list) else stage.wacc[0]
+            g = stage.perp_growth or 0.0
+            stage_tax = stage.tax_rate if stage.tax_rate is not None else tax_rate
+            nopat = revenue * margin * (1 - stage_tax)
+            reinv = g / wacc_val if wacc_val else 0.0
+            terminal_fcf = nopat * (1 - reinv)
+            terminal_value = terminal_fcf * (1 + g) / (wacc_val - g)
+            value += terminal_value / ((1 + wacc_val) ** period)
+            break
+
+        years = stage.years or 0
+        for year_idx, wacc_year in enumerate(_wacc_series(stage.wacc, years)):
+            period += 1
+
+            if stage.driver_source == "consensus":
+                stage_tax = stage.tax_rate if stage.tax_rate is not None else tax_rate
+                revenue_next = stage.revenue[year_idx]
+                ebit = stage.ebit[year_idx]
+                capex = stage.capex[year_idx]
+                margin = ebit / revenue_next if revenue_next else 0.0
+                nopat = ebit * (1 - stage_tax)
+                roic = nopat / invested if invested else 0.0
+                invested_next = invested + capex
+                fcf = nopat - capex
+                growth = revenue_next / revenue - 1 if revenue else 0.0
+
+            elif stage.driver_source == "user":
+                stage_tax = stage.tax_rate if stage.tax_rate is not None else tax_rate
+                growth = stage.revenue_growth[year_idx]
+                revenue_next = revenue * (1 + growth)
+                margin = stage.margin[year_idx]
+                ebit = revenue_next * margin
+                nopat = ebit * (1 - stage_tax)
+                roic = nopat / invested if invested else 0.0
+                reinv_rate = growth / roic if roic else 0.0
+                capex = (revenue_next - revenue) * reinv_rate
+                invested_next = invested + capex
+                fcf = nopat - capex
+
+            elif stage.driver_source == "fade":
+                stage_tax = stage.tax_rate if stage.tax_rate is not None else tax_rate
+                target_roic = stage.wacc if isinstance(stage.wacc, float) else stage.wacc[min(year_idx, len(stage.wacc) - 1)]
+                roic = roic - (roic - target_roic) / (years - year_idx)
+                next_growth = 0.0
+                if idx_stage + 1 < len(config.stages):
+                    next_stage = config.stages[idx_stage + 1]
+                    next_growth = getattr(next_stage, "perp_growth", 0.0) or 0.0
+                growth = growth_last - (growth_last - next_growth) / (years - year_idx)
+                revenue_next = revenue * (1 + growth)
+                ebit = revenue_next * margin
+                nopat = ebit * (1 - stage_tax)
+                reinv_rate = growth / roic if roic else 0.0
+                capex = (revenue_next - revenue) * reinv_rate
+                invested_next = invested + capex
+                fcf = nopat - capex
+            else:
+                raise ValueError(f"Unknown stage type: {stage.driver_source}")
+
+            discount = (1 + wacc_year) ** period
+            value += fcf / discount
+            revenue = revenue_next
+            invested = invested_next
+            growth_last = growth
+            if stage.tax_rate is not None:
+                tax_rate = stage.tax_rate
+
+    return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,0 +1,26 @@
+{
+  "stages": [
+    {
+      "driver_source": "consensus",
+      "wacc": [0.10, 0.10, 0.10],
+      "years": 3,
+      "tax_rate": 0.25,
+      "initial_revenue": 100.0,
+      "initial_invested_capital": 100.0,
+      "revenue": [105, 110, 115],
+      "ebit": [21, 22, 23],
+      "ebitda": [25, 26, 27],
+      "capex": [5, 5.5, 6]
+    },
+    {
+      "driver_source": "fade",
+      "wacc": 0.10,
+      "years": 5
+    },
+    {
+      "driver_source": "perpetual",
+      "wacc": 0.10,
+      "perp_growth": 0.03
+    }
+  ]
+}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,18 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.abspath('.'))
+
+from backend.dcf_engine.config import StageConfig, MultiStageDCFConfig
+from backend.dcf_engine.model import enterprise_value
+
+
+def test_enterprise_value_sample():
+    with open('sample_config.json', 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    stages = [StageConfig(**s) for s in data['stages']]
+    cfg = MultiStageDCFConfig(stages=stages)
+    value = enterprise_value(cfg)
+    assert round(value, 2) == 177.21
+


### PR DESCRIPTION
## Summary
- move initial values and tax rate into stage configuration
- update API, CLI and engine to read parameters from Stage 1
- adjust sample config and documentation

## Testing
- `pytest -q`
- `python -m backend.cli sample_config.json`


------
https://chatgpt.com/codex/tasks/task_e_6874be858b60832784ef389ce4556a8a